### PR TITLE
Use MLJLinearModels and DecisionTree instead of MLJScikitLearnInterface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,11 @@ version = "0.1.0"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
+MLJDecisionTreeInterface = "c6f25543-311c-4c74-83dc-3ea6d1015661"
+MLJLinearModels = "6ee0df7b-362f-4a72-a706-9e79364fb692"
 MLJMultivariateStatsInterface = "1b6a4a23-ba22-4f51-9698-8599985d3728"
-MLJScikitLearnInterface = "5ae90465-5518-4432-b9d2-8a1def2f0cab"
+Missings = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,5 +1,5 @@
-LogisticClassifier = @load LogisticClassifier pkg="ScikitLearn"
-RandomForestClassifier = @load RandomForestClassifier pkg="ScikitLearn"
+LogisticClassifier = @load LogisticClassifier pkg="MLJLinearModels"
+RandomForestClassifier = @load RandomForestClassifier pkg="DecisionTree"
 
 
 """


### PR DESCRIPTION
This would remove the need for Python, greatly reducing the project dependencies.

Closes #17. 
